### PR TITLE
restore ability to build with Visual Studio (in addition to cmake)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
-build/*
+build/
 
-Debug VC9/*
-Debug/*
-Release VC9/*
-Release/*
-x64_v140/*
-x64_v142/*
-x64_vc11/*
+Debug VC9/
+Debug/
+Release VC9/
+Release/
+x64_v140/
+x64_v142/
+x64_vc11/
 
 *.sdf
 *.suo

--- a/common/common_vc14.vcxproj
+++ b/common/common_vc14.vcxproj
@@ -104,18 +104,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)$(Platform)_$(PlatformToolset)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)_$(PlatformToolset)\$(Configuration)\</IntDir>
+    <IncludePath>$(ProjectDir)..;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_VC142|x64'">
     <OutDir>$(SolutionDir)$(Platform)_$(PlatformToolset)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)_$(PlatformToolset)\$(Configuration)\</IntDir>
+    <IncludePath>$(ProjectDir)..;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)$(Platform)_$(PlatformToolset)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)_$(PlatformToolset)\$(Configuration)\</IntDir>
+    <IncludePath>$(ProjectDir)..;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_VC142|x64'">
     <OutDir>$(SolutionDir)$(Platform)_$(PlatformToolset)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)_$(PlatformToolset)\$(Configuration)\</IntDir>
+    <IncludePath>$(ProjectDir)..;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>


### PR DESCRIPTION
Patch f21ad22971fa (_adjust include path setting in common_vc14.vcxprj_) is required.
Patch 5bff26a6de8f (_fix gitignore definitions to match as intended_) doesn't affect compilation but should be applied as well.