### PR TITLE
Added IBufferedFileStream - a faster variant of IFileStream designed …

### DIFF
--- a/cmake/headerlist.cmake
+++ b/cmake/headerlist.cmake
@@ -1,5 +1,6 @@
 set(headers
 	common/IArchive.h
+	common/IBufferedFileStream.h
 	common/IBufferStream.h
 	common/IConsole.h
 	common/ICriticalSection.h

--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -1,5 +1,6 @@
 set(sources
 	common/IArchive.cpp
+	common/IBufferedFileStream.cpp
 	common/IBufferStream.cpp
 	common/IConsole.cpp
 	common/IDataStream.cpp

--- a/common/IBufferedFileStream.cpp
+++ b/common/IBufferedFileStream.cpp
@@ -1,0 +1,120 @@
+#include "IBufferedFileStream.h"
+
+IBufferedFileStream::IBufferedFileStream() { }
+
+IBufferedFileStream::~IBufferedFileStream()
+{
+	Close();
+
+	free(streamBuffer);
+}
+
+bool IBufferedFileStream::Open(const char* name)
+{
+	bool success = IFileStream::Open(name);
+
+	if (success)
+	{
+		ReallocateStreamBuffer(streamLength);
+
+		IFileStream::ReadBuf(streamBuffer, streamLength);
+
+		IFileStream::SetOffset(0);
+	}
+
+	return success;
+}
+
+bool IBufferedFileStream::Create(const char* name)
+{
+	bool success = IFileStream::Create(name);
+
+	if (success)
+	{
+		ReallocateStreamBuffer(streamLength);
+	}
+
+	return success;
+}
+
+void IBufferedFileStream::Close(void)
+{
+	if (streamBufferHasWrite)
+	{
+		IFileStream::SetOffset(0);
+
+		IFileStream::WriteBuf(streamBuffer, streamLength);
+	}
+
+	IFileStream::Close();
+}
+
+void IBufferedFileStream::ReadBuf(void* buf, UInt32 inLength)
+{
+	ASSERT_STR(inLength <= GetRemain(), "IBufferedFileStream::ReadBuf: hit eof");
+	ASSERT_STR(streamBufferLength >= streamOffset + inLength, "IBufferedFileStream::ReadBuf: hit buffer eof");
+
+	memcpy(buf, &streamBuffer[streamOffset], inLength);
+	streamOffset += inLength;
+}
+
+void IBufferedFileStream::WriteBuf(const void* buf, UInt32 inLength)
+{
+	streamBufferHasWrite = true;
+
+	if (streamBufferLength < streamOffset + inLength)
+		ReallocateStreamBuffer(streamOffset + inLength);
+
+	memcpy(&streamBuffer[streamOffset], buf, inLength);
+	streamOffset += inLength;
+
+	if (streamLength < streamOffset)
+		streamLength = streamOffset;
+}
+
+void IBufferedFileStream::SetOffset(SInt64 inOffset)
+{
+	IDataStream::SetOffset(inOffset);
+}
+
+void IBufferedFileStream::SetLength(UInt64 length)
+{
+	ReallocateStreamBuffer(length);
+
+	IFileStream::SetLength(length);
+}
+
+void IBufferedFileStream::ReallocateStreamBuffer(UInt64 length)
+{
+	UInt64 newStreamBufferLength = CalculateStreamBufferLength(length);
+
+	if (newStreamBufferLength != streamBufferLength)
+	{
+		streamBufferLength = newStreamBufferLength;
+
+		if (streamBuffer == nullptr)
+		{
+			streamBuffer = (UInt8*)malloc(streamBufferLength);
+		}
+		else
+		{
+			UInt8* newStreamBuffer = (UInt8*)realloc(streamBuffer, streamBufferLength);
+
+			ASSERT_STR(newStreamBuffer, "IBufferedFileStream::ReallocateBuffer: realloc failed");
+
+			streamBuffer = newStreamBuffer;
+		}
+	}
+}
+
+UInt64 IBufferedFileStream::CalculateStreamBufferLength(UInt64 length)
+{
+	const UInt64 step = 1024ull * 1024ull;
+
+	if (!length) return step;
+
+	UInt64 whole = length / step;
+	UInt64 remain = length % step;
+
+	return (whole + (remain > 0 ? 1 : 0)) * step;
+}

--- a/common/IBufferedFileStream.h
+++ b/common/IBufferedFileStream.h
@@ -2,32 +2,30 @@
 
 #include "common/IDataStream.h"
 #include "common/IFileStream.h"
+#include <vector>
 
 /**
  *	An input/output file stream with buffering, write file on close
  */
-class IBufferedFileStream : public IFileStream
+class IBufferedFileStream : public IDataStream
 {
 public:
 	IBufferedFileStream();
 	virtual ~IBufferedFileStream();
 
-	virtual bool	Open(const char* name);
-	virtual bool	Create(const char* name);
+	bool	Open(const char* name);
+	bool	Create(const char* name);
 
-	virtual void	Close(void);
+	void	Close(void);
 
 	virtual void	ReadBuf(void* buf, UInt32 inLength);
 	virtual void	WriteBuf(const void* buf, UInt32 inLength);
-	virtual void	SetOffset(SInt64 inOffset);
 
-	virtual void	SetLength(UInt64 length);
+	void	SetLength(UInt64 length);
 
 private:
-	void	ReallocateStreamBuffer(UInt64 length);
-	UInt64	CalculateStreamBufferLength(UInt64 length);
+	std::vector<UInt8>	streamBuffer;
+	IFileStream			streamFile;
 
-	UInt8* streamBuffer = nullptr;
-	UInt64	streamBufferLength = 0;
 	bool	streamBufferHasWrite = false;
 };

--- a/common/IBufferedFileStream.h
+++ b/common/IBufferedFileStream.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "common/IDataStream.h"
+#include "common/IFileStream.h"
+
+/**
+ *	An input/output file stream with buffering, write file on close
+ */
+class IBufferedFileStream : public IFileStream
+{
+public:
+	IBufferedFileStream();
+	virtual ~IBufferedFileStream();
+
+	virtual bool	Open(const char* name);
+	virtual bool	Create(const char* name);
+
+	virtual void	Close(void);
+
+	virtual void	ReadBuf(void* buf, UInt32 inLength);
+	virtual void	WriteBuf(const void* buf, UInt32 inLength);
+	virtual void	SetOffset(SInt64 inOffset);
+
+	virtual void	SetLength(UInt64 length);
+
+private:
+	void	ReallocateStreamBuffer(UInt64 length);
+	UInt64	CalculateStreamBufferLength(UInt64 length);
+
+	UInt8* streamBuffer = nullptr;
+	UInt64	streamBufferLength = 0;
+	bool	streamBufferHasWrite = false;
+};

--- a/common/IFileStream.h
+++ b/common/IFileStream.h
@@ -12,22 +12,22 @@ class IFileStream : public IDataStream
 		IFileStream(const char * name);
 		~IFileStream();
 
-		virtual bool	Open(const char * name);
-		bool			BrowseOpen(void);
+		bool	Open(const char * name);
+		bool	BrowseOpen(void);
 
-		virtual bool	Create(const char * name);
-		bool			BrowseCreate(const char * defaultName = NULL, const char * defaultPath = NULL, const char * title = NULL);
+		bool	Create(const char * name);
+		bool	BrowseCreate(const char * defaultName = NULL, const char * defaultPath = NULL, const char * title = NULL);
 
-		virtual void	Close(void);
+		void	Close(void);
 
-		HANDLE			GetHandle(void)	{ return theFile; }
+		HANDLE	GetHandle(void)	{ return theFile; }
 
 		virtual void	ReadBuf(void * buf, UInt32 inLength);
 		virtual void	WriteBuf(const void * buf, UInt32 inLength);
 		virtual void	SetOffset(SInt64 inOffset);
 
 		// can truncate. implicitly seeks to the end of the file
-		virtual void	SetLength(UInt64 length);
+		void	SetLength(UInt64 length);
 
 		static void	MakeAllDirs(const char * path);
 		static char * ExtractFileName(char * path);

--- a/common/IFileStream.h
+++ b/common/IFileStream.h
@@ -3,7 +3,7 @@
 #include "common/IDataStream.h"
 
 /**
- *	An input file stream
+ *	An input/output file stream
  */
 class IFileStream : public IDataStream
 {
@@ -12,22 +12,22 @@ class IFileStream : public IDataStream
 		IFileStream(const char * name);
 		~IFileStream();
 
-		bool	Open(const char * name);
-		bool	BrowseOpen(void);
+		virtual bool	Open(const char * name);
+		bool			BrowseOpen(void);
 
-		bool	Create(const char * name);
-		bool	BrowseCreate(const char * defaultName = NULL, const char * defaultPath = NULL, const char * title = NULL);
+		virtual bool	Create(const char * name);
+		bool			BrowseCreate(const char * defaultName = NULL, const char * defaultPath = NULL, const char * title = NULL);
 
-		void	Close(void);
+		virtual void	Close(void);
 
-		HANDLE	GetHandle(void)	{ return theFile; }
+		HANDLE			GetHandle(void)	{ return theFile; }
 
 		virtual void	ReadBuf(void * buf, UInt32 inLength);
 		virtual void	WriteBuf(const void * buf, UInt32 inLength);
 		virtual void	SetOffset(SInt64 inOffset);
 
 		// can truncate. implicitly seeks to the end of the file
-		void	SetLength(UInt64 length);
+		virtual void	SetLength(UInt64 length);
 
 		static void	MakeAllDirs(const char * path);
 		static char * ExtractFileName(char * path);


### PR DESCRIPTION
…for working with small files such as kosaves.

Now when using plugins that save a lot of small chunks in the kosave, the saving itself is very slow.
For example, for Skyrim AE, when using the RaceMenu plugin, saving specific plugin data takes about 2 seconds.
If you use the new class, this time is reduced to 50 milliseconds.

I'm not very good at writing C++, but maybe this or a similar change should be made to make saving much faster?

Paired pull request for https://github.com/ianpatt/skse64/pull/44