### PR TITLE
fix: Resolve cross-compilation issues and improve platform compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,16 @@ cmake_minimum_required(VERSION 3.18)
 
 # ---- Project ----
 
-set(CMAKE_CXX_FLAGS_DEBUG "/D_DEBUG /Z7 /Ob0 /Od /RTC1" CACHE STRING "")
-set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "")
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>" CACHE STRING "")
+if(WIN32)
+    if(MSVC)
+        # Nativer Windows-Build mit MSVC Compiler
+        set(CMAKE_CXX_FLAGS_DEBUG "/D_DEBUG /Z7 /Ob0 /Od /RTC1" CACHE STRING "" FORCE)
+		set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "")
+		set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>" CACHE STRING "")
+    elseif(MINGW)
+         set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -D_DEBUG" CACHE STRING "" FORCE)
+    endif()
+endif()
 
 project(
 	common
@@ -55,6 +62,15 @@ target_include_directories(
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 		$<INSTALL_INTERFACE:include>
 )
+if(WIN32)
+	if(MINGW)
+		target_include_directories(
+			${PROJECT_NAME}
+			PRIVATE
+			"${CMAKE_SOURCE_DIR}"
+		)
+	endif()
+endif()
 
 target_precompile_headers(
 	${PROJECT_NAME}

--- a/common/IConsole.cpp
+++ b/common/IConsole.cpp
@@ -1,64 +1,66 @@
 #include "common/IConsole.h"
 #include <cstdarg>
 #include <cstring>
+#ifdef __MINGW32__
+#include <windows.h>
+#else
 #include <Windows.h>
-
+#endif
 IConsole::IConsole()
 {
 	AllocConsole();
-	
+
 	SetConsoleTitle("Console");
-	
+
 	inputHandle = GetStdHandle(STD_INPUT_HANDLE);
 	outputHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-	
+
 	ASSERT_STR(inputHandle, "IConsole: couldn't get input handle");
 	ASSERT_STR(outputHandle, "IConsole: couldn't get output handle");
-	
+
 	SetConsoleMode(inputHandle, ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
 	SetConsoleMode(outputHandle, ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT);
 }
 
 IConsole::~IConsole()
 {
-	
 }
 
 /**
  *	Writes a string to the console
  */
-void IConsole::Write(char * buf)
+void IConsole::Write(char *buf)
 {
-	UInt32	charsWritten;
-	
+	UInt32 charsWritten;
+
 	WriteConsole(outputHandle, buf, std::strlen(buf), &charsWritten, NULL);
 }
 
 /**
  *	Writes a formatted string to the console
- *	
+ *
  *	You may specify a temp buffer to use for the formatted text, but if NULL
  *	is used a local buffer will be provided.
- *	
+ *
  *	@param buf a temporary buffer, or NULL to use the internal buffer
  *	@param fmt the format string
  */
-void IConsole::Write(char * buf, UInt32 bufLen, const char * fmt, ...)
+void IConsole::Write(char *buf, UInt32 bufLen, const char *fmt, ...)
 {
-	static char	tempBuf[4096];
-	
-	if(!buf)
+	static char tempBuf[4096];
+
+	if (!buf)
 	{
 		buf = tempBuf;
 		bufLen = sizeof(tempBuf);
 	}
-	
-	va_list	args;
-	
+
+	va_list args;
+
 	va_start(args, fmt);
 	vsprintf_s(buf, bufLen, fmt, args);
 	va_end(args);
-	
+
 	Write(buf);
 }
 
@@ -67,50 +69,49 @@ void IConsole::Write(char * buf, UInt32 bufLen, const char * fmt, ...)
  */
 char IConsole::ReadChar(void)
 {
-	char	data;
-	UInt32	charsRead;
-	
+	char data;
+	UInt32 charsRead;
+
 	ReadConsole(inputHandle, &data, 1, &charsRead, NULL);
-	
+
 	return data;
 }
 
 /**
  *	Reads a newline-terminated string from the console
- *	
+ *
  *	@param buf output buffer
  *	@param len buffer size
  *	@return number of characters read
  */
-UInt32 IConsole::ReadBuf(char * buf, UInt32 len)
+UInt32 IConsole::ReadBuf(char *buf, UInt32 len)
 {
-	UInt32	charsRead;
-	
+	UInt32 charsRead;
+
 	buf[0] = 0;
-	
+
 	do
 	{
 		ReadConsole(inputHandle, buf, len, &charsRead, NULL);
-	}
-	while(!charsRead);
-	
+	} while (!charsRead);
+
 	int done = 0;
-	for(UInt32 i = charsRead - 1; (i > 0) && !done; i--)
+	for (UInt32 i = charsRead - 1; (i > 0) && !done; i--)
 	{
-		switch(buf[i])
+		switch (buf[i])
 		{
-			case 0x0A:
-			case 0x0D:
-				buf[i] = 0;
-				break;
-				
-			default:
-				done = 1;
-				break;
+		case 0x0A:
+		case 0x0D:
+			buf[i] = 0;
+			break;
+
+		default:
+			done = 1;
+			break;
 		}
 	}
-	
+
 	buf[charsRead] = 0;
-	
+
 	return charsRead;
 }

--- a/common/IConsole.h
+++ b/common/IConsole.h
@@ -2,25 +2,28 @@
 
 #include "common/ITypes.h"
 #include "common/ISingleton.h"
+#ifdef __MINGW32__
+#include <windows.h>
+#else
 #include <Windows.h>
-
+#endif
 /**
  *	Wrapper class for a standard Windows console
- *	
+ *
  *	@todo make nonblocking
  */
 class IConsole : public ISingleton<IConsole>
 {
-	public:
-				IConsole();
-				~IConsole();
-		
-		void	Write(char * buf);
-		void	Write(char * buf, UInt32 bufLen, const char * fmt, ...);
-		
-		char	ReadChar(void);
-		UInt32	ReadBuf(char * buf, UInt32 len);
-	
-	private:
-		HANDLE	inputHandle, outputHandle;
+public:
+	IConsole();
+	~IConsole();
+
+	void Write(char *buf);
+	void Write(char *buf, UInt32 bufLen, const char *fmt, ...);
+
+	char ReadChar(void);
+	UInt32 ReadBuf(char *buf, UInt32 len);
+
+private:
+	HANDLE inputHandle, outputHandle;
 };

--- a/common/IDatabase.h
+++ b/common/IDatabase.h
@@ -2,115 +2,114 @@
 
 #include <map>
 #include "common/IDataStream.h"
-#include "common/IFilestream.h"
+#include "common/IFileStream.h"
 
 template <class DataType>
 class IDatabase
 {
-	public:
-		typedef std::map <UInt64, DataType>		DataMapType;
-		typedef typename DataMapType::iterator	DataMapIterator;
+public:
+	typedef std::map<UInt64, DataType> DataMapType;
+	typedef typename DataMapType::iterator DataMapIterator;
 
-		static const UInt64	kGUIDMask = 0x0FFFFFFFFFFFFFFF;
+	static const UInt64 kGUIDMask = 0x0FFFFFFFFFFFFFFF;
 
-		IDatabase()	{ newKeyHint = 1; }
-		virtual ~IDatabase()	{ }
+	IDatabase() { newKeyHint = 1; }
+	virtual ~IDatabase() {}
 
-		DataType *	Get(UInt64 key)
+	DataType *Get(UInt64 key)
+	{
+		key &= kGUIDMask;
+
+		if (!key)
+			return NULL;
+
+		typename DataMapType::iterator iter = theDataMap.find(key);
+
+		return (iter == theDataMap.end()) ? NULL : &((*iter).second);
+	}
+
+	DataType *Alloc(UInt64 key)
+	{
+		key &= kGUIDMask;
+
+		if (!key)
+			return NULL;
+
+		typename DataMapType::iterator iter = theDataMap.find(key);
+
+		return (iter == theDataMap.end()) ? &theDataMap[key] : NULL;
+	}
+
+	DataType *Alloc(UInt64 *key)
+	{
+		UInt64 newKey = newKeyHint;
+
+		do
 		{
-			key &= kGUIDMask;
+			if (!newKey)
+				newKey++;
 
-			if(!key)
-				return NULL;
+			typename DataMapType::iterator iter = theDataMap.find(newKey);
 
-			DataMapType::iterator	iter = theDataMap.find(key);
-
-			return (iter == theDataMap.end()) ? NULL : &((*iter).second);
-		}
-
-		DataType *	Alloc(UInt64 key)
-		{
-			key &= kGUIDMask;
-
-			if(!key)
-				return NULL;
-
-			DataMapType::iterator	iter = theDataMap.find(key);
-
-			return (iter == theDataMap.end()) ? &theDataMap[key] : NULL;
-		}
-
-		DataType *	Alloc(UInt64 * key)
-		{
-			UInt64	newKey = newKeyHint;
-
-			do
+			// is 'newKey' unused?
+			if (iter == theDataMap.end())
 			{
-				if(!newKey)
-					newKey++;
-
-				DataMapType::iterator	iter = theDataMap.find(newKey);
-
-				// is 'newKey' unused?
-				if(iter == theDataMap.end())
+				*key = newKey;
+				newKeyHint = (newKey + 1) & kGUIDMask;
+				return &theDataMap[newKey];
+			}
+			else
+			{
+				++iter;
+				if (iter == theDataMap.end())
 				{
-					*key = newKey;
-					newKeyHint = (newKey + 1) & kGUIDMask;
-					return &theDataMap[newKey];
+					newKey = 1;
 				}
 				else
 				{
-					++iter;
-					if(iter == theDataMap.end())
+					UInt64 nextKey = (newKey + 1) & kGUIDMask;
+					if (iter->first != nextKey)
 					{
-						newKey = 1;
-					}
-					else
-					{
-						UInt64	nextKey = (newKey + 1) & kGUIDMask;
-						if(iter->first != nextKey)
-						{
-							*key = nextKey;
-							newKeyHint = (nextKey + 1) & kGUIDMask;
-							return &theDataMap[nextKey];
-						}
+						*key = nextKey;
+						newKeyHint = (nextKey + 1) & kGUIDMask;
+						return &theDataMap[nextKey];
 					}
 				}
 			}
-			while(1);
+		} while (1);
 
-			*key = 0;
+		*key = 0;
 
-			return NULL;
-		}
+		return NULL;
+	}
 
-		void		Delete(UInt64 key)
+	void Delete(UInt64 key)
+	{
+		if (key)
 		{
-			if(key)
-			{
-				key &= kGUIDMask;
+			key &= kGUIDMask;
 
-				theDataMap.erase(key);
+			theDataMap.erase(key);
 
-				newKeyHint = key;
-			}
+			newKeyHint = key;
 		}
+	}
 
-		void		Save(IDataStream * stream);
-		void		Load(IDataStream * stream);
+	void Save(IDataStream *stream);
+	void Load(IDataStream *stream);
 
-		bool		SaveToFile(char * name);
-		bool		LoadFromFile(char * name);
+	bool SaveToFile(char *name);
+	bool LoadFromFile(char *name);
 
-		DataMapType &	GetData(void)		{ return theDataMap; }
+	DataMapType &GetData(void) { return theDataMap; }
 
-		DataMapIterator	Begin(void)		{ return theDataMap.begin(); }
-		DataMapIterator	End(void)		{ return theDataMap.end(); }
-		UInt32			Length(void)	{ return theDataMap.size(); }
+	DataMapIterator Begin(void) { return theDataMap.begin(); }
+	DataMapIterator End(void) { return theDataMap.end(); }
+	UInt32 Length(void) { return theDataMap.size(); }
 
-	private:
-		DataMapType	theDataMap;
-		UInt64		newKeyHint;
+private:
+	DataMapType theDataMap;
+	UInt64 newKeyHint;
 };
 
 #include "common/IDatabase.inc"

--- a/common/IDatabase.inc
+++ b/common/IDatabase.inc
@@ -4,7 +4,7 @@ void IDatabase <DataType>::Save(IDataStream * stream)
 	stream->Write32(theDataMap.size());
 	stream->Write64(newKeyHint);
 	
-	for(DataMapType::iterator iter = theDataMap.begin(); iter != theDataMap.end(); iter++)
+	for(typename DataMapType::iterator iter = theDataMap.begin(); iter != theDataMap.end(); iter++)
 	{
 		stream->Write64((*iter).first);
 		stream->WriteBuf(&((*iter).second), sizeof(DataType));
@@ -53,3 +53,4 @@ bool IDatabase <DataType>::LoadFromFile(char * name)
 
 	return false;
 }
+

--- a/common/IErrors.cpp
+++ b/common/IErrors.cpp
@@ -6,17 +6,21 @@
 __declspec(noreturn) static void IErrors_Halt(void)
 {
 	// crash
+#if defined(_MSC_VER)
 	__ud2();
+#elif defined(__GNUC__) || defined(__clang__)
+	__builtin_trap();
+#endif
 }
 
 /**
  *	Report a failed assertion and exit the program
- *	
+ *
  *	@param file the file where the error occured
  *	@param line the line number where the error occured
  *	@param desc an error message
  */
-void _AssertionFailed(const char * file, unsigned long line, const char * desc)
+void _AssertionFailed(const char *file, unsigned long line, const char *desc)
 {
 	_FATALERROR("Assertion failed in %s (%d): %s", file, line, desc);
 
@@ -25,34 +29,34 @@ void _AssertionFailed(const char * file, unsigned long line, const char * desc)
 
 /**
  *	Report a failed assertion and exit the program
- *	
+ *
  *	@param file the file where the error occured
  *	@param line the line number where the error occured
  *	@param desc an error message
  *	@param code the error code
  */
-void _AssertionFailed_ErrCode(const char * file, unsigned long line, const char * desc, unsigned long long code)
+void _AssertionFailed_ErrCode(const char *file, unsigned long line, const char *desc, unsigned long long code)
 {
-	if(code & 0xFFFFFFFF00000000)
+	if (code & 0xFFFFFFFF00000000)
 		_FATALERROR("Assertion failed in %s (%d): %s (code = %16I64X (%I64d))", file, line, desc, code, code);
 	else
 	{
-		UInt32	code32 = code;
+		UInt32 code32 = code;
 		_FATALERROR("Assertion failed in %s (%d): %s (code = %08X (%d))", file, line, desc, code32, code32);
 	}
-	
+
 	IErrors_Halt();
 }
 
 /**
  *	Report a failed assertion and exit the program
- *	
+ *
  *	@param file the file where the error occured
  *	@param line the line number where the error occured
  *	@param desc an error message
  *	@param code the error code
  */
-void _AssertionFailed_ErrCode(const char * file, unsigned long line, const char * desc, const char * code)
+void _AssertionFailed_ErrCode(const char *file, unsigned long line, const char *desc, const char *code)
 {
 	_FATALERROR("Assertion failed in %s (%d): %s (code = %s)", file, line, desc, code);
 

--- a/common/IFileStream.cpp
+++ b/common/IFileStream.cpp
@@ -4,13 +4,12 @@
 #include <direct.h>
 
 IFileStream::IFileStream()
-:theFile(INVALID_HANDLE_VALUE)
+	: theFile(INVALID_HANDLE_VALUE)
 {
-	
 }
 
-IFileStream::IFileStream(const char * name)
-:theFile(INVALID_HANDLE_VALUE)
+IFileStream::IFileStream(const char *name)
+	: theFile(INVALID_HANDLE_VALUE)
 {
 	Open(name);
 }
@@ -23,14 +22,14 @@ IFileStream::~IFileStream()
 /**
  *	Opens a file for reading and attaches it to the stream
  */
-bool IFileStream::Open(const char * name)
+bool IFileStream::Open(const char *name)
 {
 	Close();
 
 	theFile = CreateFile(name, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-	if(theFile != INVALID_HANDLE_VALUE)
+	if (theFile != INVALID_HANDLE_VALUE)
 	{
-		LARGE_INTEGER	temp;
+		LARGE_INTEGER temp;
 
 		GetFileSizeEx(theFile, &temp);
 
@@ -48,35 +47,35 @@ static UINT_PTR CALLBACK BrowseEventProc(HWND window, UINT msg, WPARAM wParam, L
 
 bool IFileStream::BrowseOpen(void)
 {
-	bool			result = false;
-	OPENFILENAME	info;
-	char			path[4096];
+	bool result = false;
+	OPENFILENAME info;
+	char path[4096];
 
 	path[0] = 0;
 
-	info.lStructSize =			sizeof(info);
-	info.hwndOwner =			NULL;
-	info.hInstance =			NULL;
-	info.lpstrFilter =			NULL;
-	info.lpstrCustomFilter =	NULL;
-	info.nMaxCustFilter =		0;
-	info.nFilterIndex =			0;
-	info.lpstrFile =			path;
-	info.nMaxFile =				sizeof(path);
-	info.lpstrFileTitle =		NULL;
-	info.nMaxFileTitle =		0;
-	info.lpstrInitialDir =		NULL;
-	info.lpstrTitle =			NULL;
-	info.Flags =				OFN_EXPLORER | OFN_ENABLESIZING | OFN_FILEMUSTEXIST | OFN_ENABLEHOOK | OFN_NOCHANGEDIR;
-	info.lpstrDefExt =			NULL;
-	info.lCustData =			NULL;
-	info.lpfnHook =				BrowseEventProc;
-	info.lpTemplateName =		NULL;
-//	info.pvReserved =			NULL;
-//	info.dwReserved =			NULL;
-//	info.FlagsEx =				0;
+	info.lStructSize = sizeof(info);
+	info.hwndOwner = NULL;
+	info.hInstance = NULL;
+	info.lpstrFilter = NULL;
+	info.lpstrCustomFilter = NULL;
+	info.nMaxCustFilter = 0;
+	info.nFilterIndex = 0;
+	info.lpstrFile = path;
+	info.nMaxFile = sizeof(path);
+	info.lpstrFileTitle = NULL;
+	info.nMaxFileTitle = 0;
+	info.lpstrInitialDir = NULL;
+	info.lpstrTitle = NULL;
+	info.Flags = OFN_EXPLORER | OFN_ENABLESIZING | OFN_FILEMUSTEXIST | OFN_ENABLEHOOK | OFN_NOCHANGEDIR;
+	info.lpstrDefExt = NULL;
+	info.lCustData = 0;
+	info.lpfnHook = BrowseEventProc;
+	info.lpTemplateName = NULL;
+	//	info.pvReserved =			NULL;
+	//	info.dwReserved =			NULL;
+	//	info.FlagsEx =				0;
 
-	if(GetOpenFileName(&info))
+	if (GetOpenFileName(&info))
 	{
 		result = Open(path);
 	}
@@ -88,12 +87,12 @@ bool IFileStream::BrowseOpen(void)
  *	Creates a new file for writing, overwriting any previously-existing files,
  *	and attaches it to the stream
  */
-bool IFileStream::Create(const char * name)
+bool IFileStream::Create(const char *name)
 {
 	Close();
 
 	theFile = CreateFile(name, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-	if(theFile != INVALID_HANDLE_VALUE)
+	if (theFile != INVALID_HANDLE_VALUE)
 	{
 		streamLength = 0;
 		streamOffset = 0;
@@ -102,39 +101,39 @@ bool IFileStream::Create(const char * name)
 	return theFile != INVALID_HANDLE_VALUE;
 }
 
-bool IFileStream::BrowseCreate(const char * defaultName, const char * defaultPath, const char * title)
+bool IFileStream::BrowseCreate(const char *defaultName, const char *defaultPath, const char *title)
 {
-	bool			result = false;
-	OPENFILENAME	info;
-	char			path[4096];
+	bool result = false;
+	OPENFILENAME info;
+	char path[4096];
 
-	if(defaultName)
+	if (defaultName)
 		strcpy_s(path, sizeof(path), defaultName);
 
-	info.lStructSize =			sizeof(info);
-	info.hwndOwner =			NULL;
-	info.hInstance =			NULL;
-	info.lpstrFilter =			NULL;
-	info.lpstrCustomFilter =	NULL;
-	info.nMaxCustFilter =		0;
-	info.nFilterIndex =			0;
-	info.lpstrFile =			path;
-	info.nMaxFile =				sizeof(path);
-	info.lpstrFileTitle =		NULL;
-	info.nMaxFileTitle =		0;
-	info.lpstrInitialDir =		defaultPath;
-	info.lpstrTitle =			title;
-	info.Flags =				OFN_EXPLORER | OFN_ENABLESIZING | OFN_ENABLEHOOK |
-								OFN_NOCHANGEDIR | OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
-	info.lpstrDefExt =			NULL;
-	info.lCustData =			NULL;
-	info.lpfnHook =				BrowseEventProc;
-	info.lpTemplateName =		NULL;
-//	info.pvReserved =			NULL;
-//	info.dwReserved =			NULL;
-//	info.FlagsEx =				0;
+	info.lStructSize = sizeof(info);
+	info.hwndOwner = NULL;
+	info.hInstance = NULL;
+	info.lpstrFilter = NULL;
+	info.lpstrCustomFilter = NULL;
+	info.nMaxCustFilter = 0;
+	info.nFilterIndex = 0;
+	info.lpstrFile = path;
+	info.nMaxFile = sizeof(path);
+	info.lpstrFileTitle = NULL;
+	info.nMaxFileTitle = 0;
+	info.lpstrInitialDir = defaultPath;
+	info.lpstrTitle = title;
+	info.Flags = OFN_EXPLORER | OFN_ENABLESIZING | OFN_ENABLEHOOK |
+				 OFN_NOCHANGEDIR | OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
+	info.lpstrDefExt = NULL;
+	info.lCustData = 0;
+	info.lpfnHook = BrowseEventProc;
+	info.lpTemplateName = NULL;
+	//	info.pvReserved =			NULL;
+	//	info.dwReserved =			NULL;
+	//	info.FlagsEx =				0;
 
-	if(GetSaveFileName(&info))
+	if (GetSaveFileName(&info))
 	{
 		result = Create(path);
 	}
@@ -147,41 +146,41 @@ bool IFileStream::BrowseCreate(const char * defaultName, const char * defaultPat
  */
 void IFileStream::Close(void)
 {
-	if(theFile)
+	if (theFile)
 	{
 		CloseHandle(theFile);
 		theFile = INVALID_HANDLE_VALUE;
 	}
 }
 
-void IFileStream::ReadBuf(void * buf, UInt32 inLength)
+void IFileStream::ReadBuf(void *buf, UInt32 inLength)
 {
-	UInt32	bytesRead;
+	UInt32 bytesRead;
 
 	ReadFile(theFile, buf, inLength, &bytesRead, NULL);
 
 	streamOffset += bytesRead;
 }
 
-void IFileStream::WriteBuf(const void * buf, UInt32 inLength)
+void IFileStream::WriteBuf(const void *buf, UInt32 inLength)
 {
-	UInt32	bytesWritten;
+	UInt32 bytesWritten;
 
 	// check for file expansion
-	if(streamOffset > streamLength)
+	if (streamOffset > streamLength)
 		SetEndOfFile(theFile);
 
 	WriteFile(theFile, buf, inLength, &bytesWritten, NULL);
 
 	streamOffset += bytesWritten;
 
-	if(streamLength < streamOffset)
+	if (streamLength < streamOffset)
 		streamLength = streamOffset;
 }
 
 void IFileStream::SetOffset(SInt64 inOffset)
 {
-	LARGE_INTEGER	temp;
+	LARGE_INTEGER temp;
 
 	temp.QuadPart = inOffset;
 
@@ -198,19 +197,19 @@ void IFileStream::SetLength(UInt64 length)
 }
 
 // ### TODO: get rid of buf
-void IFileStream::MakeAllDirs(const char * path)
+void IFileStream::MakeAllDirs(const char *path)
 {
-	char	buf[1024];
-	char	* traverse = buf;
+	char buf[1024];
+	char *traverse = buf;
 
-	while(1)
+	while (1)
 	{
-		char	data = *path++;
+		char data = *path++;
 
-		if(!data)
+		if (!data)
 			break;
 
-		if((data == '\\') || (data == '/'))
+		if ((data == '\\') || (data == '/'))
 		{
 			*traverse = 0;
 			_mkdir(buf);
@@ -220,19 +219,19 @@ void IFileStream::MakeAllDirs(const char * path)
 	}
 }
 
-char * IFileStream::ExtractFileName(char * path)
+char *IFileStream::ExtractFileName(char *path)
 {
-	char	* traverse = path;
-	char	* lastSlash = NULL;
+	char *traverse = path;
+	char *lastSlash = NULL;
 
-	while(1)
+	while (1)
 	{
-		char	data = *traverse++;
+		char data = *traverse++;
 
-		if((data == '\\') || (data == '/'))
+		if ((data == '\\') || (data == '/'))
 			lastSlash = traverse;
 
-		if(!data)
+		if (!data)
 			break;
 	}
 

--- a/common/IPrefix.h
+++ b/common/IPrefix.h
@@ -8,10 +8,10 @@
 // 4288 - disable warning for crap microsoft extension screwing up the scope of variables defined in for loops
 // 4311 - pointer truncation
 // 4312 - pointer extension
-#pragma warning(disable: 4018 4200 4244 4267 4305 4288 4312 4311)
+#pragma warning(disable : 4018 4200 4244 4267 4305 4288 4312 4311)
 
 // need win8 for windows store APIs
-#define _WIN32_WINNT	0x0602
+#define _WIN32_WINNT 0x0602
 
 #include <cstdlib>
 #include <cstdio>
@@ -23,4 +23,8 @@
 #include "common/IDebugLog.h"
 #include "common/ISingleton.h"
 #include <winsock2.h>
+#ifdef __MINGW32__
+#include <windows.h>
+#else
 #include <Windows.h>
+#endif

--- a/common/IRangeMap.h
+++ b/common/IRangeMap.h
@@ -11,17 +11,17 @@ class IRangeMap
 public:
 	struct Entry
 	{
-		bool	Contains(t_key addr, t_key base)
+		bool Contains(t_key addr, t_key base)
 		{
 			return (addr >= base) && (addr <= (base + length - 1));
 		}
 
-		t_key	length;
-		t_data	data;
+		t_key length;
+		t_data data;
 	};
 
-	typedef std::map <t_key, Entry>			EntryMapType;
-	typedef typename EntryMapType::iterator	Iterator;
+	typedef std::map<t_key, Entry> EntryMapType;
+	typedef typename EntryMapType::iterator Iterator;
 
 	IRangeMap()
 	{
@@ -33,22 +33,22 @@ public:
 		//
 	}
 
-	void	Clear(void)
+	void Clear(void)
 	{
 		m_entries.clear();
 	}
 
-	t_data *	Add(t_key start, t_key length)
+	t_data *Add(t_key start, t_key length)
 	{
-		t_data	* result = NULL;
-		Entry	* entry = NULL;
+		t_data *result = NULL;
+		Entry *entry = NULL;
 
-		t_key	end = start + length - 1;
+		t_key end = start + length - 1;
 
-		if(end >= start)	// check for overflow ### should also check for overflow on length - 1, but that's pedantic
+		if (end >= start) // check for overflow ### should also check for overflow on length - 1, but that's pedantic
 		{
 			// special-case empty lists
-			if(m_entries.empty())
+			if (m_entries.empty())
 			{
 				entry = &m_entries[start];
 			}
@@ -56,15 +56,15 @@ public:
 			{
 				// collision check
 
-				EntryMapType::iterator	iter = m_entries.lower_bound(start);
+				typename EntryMapType::iterator iter = m_entries.lower_bound(start);
 				// iter contains the first entry at or after start (or null)
 
-				if(iter == m_entries.begin())
+				if (iter == m_entries.begin())
 				{
 					// there can't be anything before this entry
 					// so we only need to check if it's colliding with us
 
-					if(iter->first > end)
+					if (iter->first > end)
 					{
 						// can't provide a hint because we're inserting at the top
 						entry = &m_entries[start];
@@ -74,22 +74,22 @@ public:
 				{
 					// see if this entry doesn't collide
 					// can be null (null entries don't collide)
-					if((iter == m_entries.end()) || (iter->first > end))
+					if ((iter == m_entries.end()) || (iter->first > end))
 					{
 						// we didn't get the first entry in the map
 						// and there is at least one entry in the map
 						// therefore there's an entry before iter
-						EntryMapType::iterator	preIter = iter;
+						typename EntryMapType::iterator preIter = iter;
 						preIter--;
 
 						// check if this collides
 						// guaranteed to be the first entry before start
-						t_key	preEnd = preIter->first + preIter->second.length - 1;
+						t_key preEnd = preIter->first + preIter->second.length - 1;
 
-						if(preEnd < start)
+						if (preEnd < start)
 						{
 							// cool, everything's fine, allocate it
-							EntryMapType::iterator	newEntry = m_entries.insert(preIter, EntryMapType::value_type(start, Entry()));
+							typename EntryMapType::iterator newEntry = m_entries.insert(preIter, typename EntryMapType::value_type(start, Entry()));
 							entry = &newEntry->second;
 						}
 					}
@@ -98,7 +98,7 @@ public:
 		}
 
 		// set up the entry
-		if(entry)
+		if (entry)
 		{
 			entry->length = length;
 
@@ -108,15 +108,17 @@ public:
 		return result;
 	}
 
-	t_data *	Lookup(t_key addr, t_key * base = NULL, t_key * length = NULL)
+	t_data *Lookup(t_key addr, t_key *base = NULL, t_key *length = NULL)
 	{
-		t_data	* result = NULL;
+		t_data *result = NULL;
 
-		EntryMapType::iterator	iter = LookupIter(addr);
-		if(iter != m_entries.end())
+		typename EntryMapType::iterator iter = LookupIter(addr);
+		if (iter != m_entries.end())
 		{
-			if(base) *base = iter->first;
-			if(length) *length = iter->second.length;
+			if (base)
+				*base = iter->first;
+			if (length)
+				*length = iter->second.length;
 
 			result = &iter->second.data;
 		}
@@ -124,15 +126,17 @@ public:
 		return result;
 	}
 
-	bool	Erase(t_key addr, t_key * base = NULL, t_key * length = NULL)
+	bool Erase(t_key addr, t_key *base = NULL, t_key *length = NULL)
 	{
 		bool result = false;
 
-		EntryMapType::iterator	iter = LookupIter(addr);
-		if(iter != m_entries.end())
+		typename EntryMapType::iterator iter = LookupIter(addr);
+		if (iter != m_entries.end())
 		{
-			if(base) *base = iter->first;
-			if(length) *length = iter->second.length;
+			if (base)
+				*base = iter->first;
+			if (length)
+				*length = iter->second.length;
 
 			m_entries.erase(iter);
 
@@ -142,49 +146,49 @@ public:
 		return result;
 	}
 
-	t_key	GetDataRangeLength(t_data * data)
+	t_key GetDataRangeLength(t_data *data)
 	{
-		Entry	* entry = reinterpret_cast <Entry *>(reinterpret_cast <UInt8 *>(data) - offsetof(Entry, data));
+		Entry *entry = reinterpret_cast<Entry *>(reinterpret_cast<UInt8 *>(data) - offsetof(Entry, data));
 
 		return entry->length;
 	}
 
-	typename EntryMapType::iterator	LookupIter(t_key addr)
+	typename EntryMapType::iterator LookupIter(t_key addr)
 	{
-		EntryMapType::iterator	result = m_entries.end();
+		typename EntryMapType::iterator result = m_entries.end();
 
-		if(!m_entries.empty())
+		if (!m_entries.empty())
 		{
 			// we need to find the last entry less than or equal to addr
 
 			// find the first entry not less than addr
-			EntryMapType::iterator	iter = m_entries.lower_bound(addr);
+			typename EntryMapType::iterator iter = m_entries.lower_bound(addr);
 
 			// iter is either equal to addr, greater than addr, or the end
-			if(iter == m_entries.end())
+			if (iter == m_entries.end())
 			{
 				// iter is the end
 				// can only be in the entry before this
 				// which does exist because map isn't empty
 				--iter;
 
-				if(iter->second.Contains(addr, iter->first))
+				if (iter->second.Contains(addr, iter->first))
 				{
 					result = iter;
 				}
 			}
 			// at this point iter must be valid
-			else if(iter->first > addr)
+			else if (iter->first > addr)
 			{
 				// iter is greater than addr
 				// can only be in the entry before this
 				// but there may not be an entry before this
 
-				if(iter != m_entries.begin())
+				if (iter != m_entries.begin())
 				{
 					--iter;
 
-					if(iter->second.Contains(addr, iter->first))
+					if (iter->second.Contains(addr, iter->first))
 					{
 						result = iter;
 					}
@@ -200,16 +204,16 @@ public:
 		return result;
 	}
 
-	typename EntryMapType::iterator	Begin(void)
+	typename EntryMapType::iterator Begin(void)
 	{
 		return m_entries.begin();
 	}
 
-	typename EntryMapType::iterator	End(void)
+	typename EntryMapType::iterator End(void)
 	{
 		return m_entries.end();
 	}
 
 private:
-	EntryMapType	m_entries;
+	EntryMapType m_entries;
 };


### PR DESCRIPTION
- Add typename keywords for dependent type names in template contexts (IDatabase.h, IDatabase.inc, IRangeMap.h)
  * Fixes GCC/MinGW compilation errors about missing typename for dependent scopes
  * Fully compatible with MSVC - no breaking changes

- Fix NULL to LPARAM conversion warnings (IFileStream.cpp)
  * Changed info.lCustData assignments from NULL to integer 0
  * Resolves -Wconversion-null warnings in GCC/MinGW
  * MSVC accepts both forms identically

- Add Windows-specific include guards for MinGW compatibility
  * IPrefix.h: Wrap Windows.h includes with __MINGW32__ check
  * IConsole.h/cpp: Same pattern for clean header inclusion
  * Ensures proper API availability across compiler toolchains

- Enhance CMakeLists.txt cross-platform support:
  * Split MSVC/MinGW debug configuration blocks
  * MSVC: Keep /Z7, /RTC1 runtime checks (original behavior)
  * MinGW: Use -g, -O0 equivalent flags
  * Add PRIVATE include path for MINGW builds

- Code formatting cleanup:
  * Normalize whitespace and indentation across multiple files
  * Consistent spacing around operators and parentheses

Total: Template typename fixes + NULL→LPARAM conversions + Windows API
       include guards = cross-platform compatible code that compiles cleanly
       on both MSVC and MinGW toolchains.