### PR TITLE
Find the include also on case-sensitive file systems.

### DIFF
--- a/common/IDatabase.h
+++ b/common/IDatabase.h
@@ -2,7 +2,7 @@
 
 #include <map>
 #include "common/IDataStream.h"
-#include "common/IFilestream.h"
+#include "common/IFileStream.h"
 
 template <class DataType>
 class IDatabase


### PR DESCRIPTION
Needed if cross-compiling on Linux.
